### PR TITLE
CTECH-1588: Adds access_token to config.

### DIFF
--- a/sdk/lusid_scheduler/utilities/config_keys.json
+++ b/sdk/lusid_scheduler/utilities/config_keys.json
@@ -42,5 +42,9 @@
   "proxy_password": {
       "env": "FBN_PROXY_PASSWORD",
       "config": "password"
+  },
+  "access_token": {
+    "env": "FBN_ACCESS_TOKEN",
+    "config": "accessToken"
   }
 }


### PR DESCRIPTION
Signed-off-by: Paul Saunders <paul.saunders@finbourne.com>

# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass

# Description of the PR

Adds the access token to the config to work with the newer version of finbourne-sdk-utilities.
